### PR TITLE
feat: 🎸 #5: Add summary as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,16 @@ With `cwd` set:
     cwd: ./src
 ```
 
-You need to install the packages beforehand to display values of the `current` culumn.
+You need to install the packages beforehand to display values of the `current` column.
+
+You can use the `summary` output in other actions, for example to send an email or comment on your pull request
+```yaml
+- run: npm ci
+- uses: gh640/npm-outdated-action@v1
+  id: npm-outdated
+- name: Do something with the summary
+  run: echo ${{ steps.npm-outdated.outputs.summary }}
+```
 
 ### Inputs
 
@@ -34,6 +43,7 @@ You need to install the packages beforehand to display values of the `current` c
 
 | name | description |
 | --- | --- |
+| `summary` | summary of the action run, containing the table |
 | `exitCode` | exit code of the command |
 | `stdout` | standard output of the command |
 | `stderr` | standard error of the command |

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
             .addTable([header, ...rows])
             .write()
           // Set the summary output
-          core.setOutput('summary', core.summary._buffer)
+          core.setOutput('summary', core.summary.stringify())
       env:
         CWD: ${{ inputs.cwd }}
       id: npm_outdated

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ outputs:
   stderr:
     description: 'Stderr of the command'
     value: ${{ steps.npm_outdated.outputs.stderr }}
+  summary:
+    description: 'Summary of the action run, containing the table'
+    value: ${{ steps.npm_outdated.outputs.summary }}
 runs:
   using: 'composite'
   steps:
@@ -54,6 +57,8 @@ runs:
             .addHeading('Outdated packages :broom:')
             .addTable([header, ...rows])
             .write()
+          // Set the summary output
+          core.setOutput('summary', core.summary._buffer)
       env:
         CWD: ${{ inputs.cwd }}
       id: npm_outdated


### PR DESCRIPTION
This pull request adds the `summary` of the action as an additional output.

closes #5 

If the user wants, they can use this summary and do further processing, e.g. send an email with the outdated table, automatically comment on a pull request, etc.

I have added a simple example with `echo` to the README, but it could also show examples for sending emails or commenting on PRs, I'm not sure what's best.

```yaml
- uses: gh640/npm-outdated-action@main
  id: npm-outdated
- name: Comment PR
  uses: thollander/actions-comment-pull-request@v3
  with:
    message: ${{ steps.npm_outdated.outputs.summary }}
    comment-tag: npm-outdated
```
Results in
![image](https://github.com/user-attachments/assets/7d00a671-08ec-43cf-9d59-b6046abb349a)
